### PR TITLE
fix: broken links when SITE_BASE was empty or simply broken

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { SocialLinks, WebsiteLinks } from '../consts'
+import { SITE_BASE, SocialLinks, WebsiteLinks } from '../consts'
 import LogoSVG from '../assets/logo.svg'
 import { Icon } from 'astro-icon/components'
 
@@ -11,7 +11,7 @@ const today = new Date()
 		class="app-container grid md:grid-cols-3 gap-12 py-16 border-t-2 border-foreground/50 dark:border-foreground-dark/50"
 	>
 		<div>
-			<a href="/" class="block w-fit" aria-label="Home">
+			<a href={`${SITE_BASE}/`} class="block w-fit" aria-label="Home">
 				<LogoSVG height={36} width={36} />
 			</a>
 		</div>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -9,7 +9,7 @@ import LogoSVG from '../assets/logo.svg'
 <header class="fixed top-0 w-full z-40 bg-background dark:bg-background-dark">
 	<nav class="">
 		<div class="app-container flex justify-between items-center py-5">
-			<a href=`${SITE_BASE}/` aria-label="Home">
+			<a href={`${SITE_BASE}/`} aria-label="Home">
 				<LogoSVG height={36} width={36} />
 			</a>
 			<div class="gap-8 hidden md:flex items-center">

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -51,7 +51,10 @@ import LogoSVG from '../assets/logo.svg'
 				<div class="flex flex-col h-full items-start gap-8 pt-16">
 					{
 						WebsiteLinks.map((link) => (
-							<NavbarLink class="text-4xl font-light" href={link.url}>
+							<NavbarLink
+								class="text-4xl font-light"
+								href={`${SITE_BASE}/${link.url}`}
+							>
 								{link.name}
 							</NavbarLink>
 						))

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -32,7 +32,7 @@ export const SocialLinks = [
 export const WebsiteLinks = [
 	{
 		name: 'Home',
-		url: '/',
+		url: '',
 	},
 	{
 		name: 'Blog',

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro'
+import { SITE_BASE } from '../consts'
 ---
 
 <BaseLayout>
@@ -15,9 +16,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 			<p class="text-xl text-center max-w-[480px]">
 				The page you're looking for wasn't found. Please check the link again.
 			</p>
-			<a class="btn-primary" href="/" download target="_blank"
-				>Go to Home Page
-			</a>
+			<a class="btn-primary" href={`${SITE_BASE}/`}>Go to Home Page </a>
 		</main>
 	</div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,7 @@ const posts = (await getCollection('blog'))
 		<div class="posts-grid-container">
 			{posts.map((post) => <BlogCard post={post} />)}
 		</div>
-		<a class="btn-secondary" href="/blog"
+		<a class="btn-secondary" href={`${SITE_BASE}/blog`}
 			>Read All
 			<Icon size={20} name="mdi:arrow-right" />
 		</a>


### PR DESCRIPTION
This pull request updates navigation and link handling across several components to consistently use the `SITE_BASE` constant for all internal URLs. This change improves maintainability and ensures that links work correctly regardless of the site's base path configuration. Fixing the issue open by me #7

**Navigation and Link Consistency:**

* Updated all internal links in `Footer.astro`, `Navbar.astro`, `404.astro`, and `index.astro` to use the `SITE_BASE` constant, ensuring consistent URL generation throughout the app. [[1]](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159L14-R14) [[2]](diffhunk://#diff-17d65d0f553fedd3c74f4bfceb6be7a20cd69be8066c6014f299cf5c0a4404a7L12-R12) [[3]](diffhunk://#diff-5469552aae112a05ce85607832e7beb863099d90e1a45e73b7c784d9a8ce6b6eL18-R19) [[4]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L45-R45)

**Codebase Improvements:**

* Imported `SITE_BASE` in relevant files (`Footer.astro`, `404.astro`) to support the new link structure. [[1]](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159L2-R2) [[2]](diffhunk://#diff-5469552aae112a05ce85607832e7beb863099d90e1a45e73b7c784d9a8ce6b6eR3)
* Updated `WebsiteLinks` in `consts.ts` so the 'Home' link uses an empty string for its URL, simplifying link concatenation logic.
* Modified the mapping of website links in the navbar to prepend `SITE_BASE` to each link, ensuring all navigation routes are correctly constructed.